### PR TITLE
Add support for getting (multiple) FileURLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ dmypy.json
 poetry.lock
 .DS_Store
 README.html
+
+/a.out

--- a/README.md
+++ b/README.md
@@ -60,7 +60,20 @@ takes two arguments:
 
 **type** - The format to set. Defaults to `pasteboard.String`, which corresponds to [NSPasteboardTypeString](https://developer.apple.com/documentation/appkit/nspasteboardtypestring?language=objc). See the `pasteboard` module members for other options such as HTML fragment, RTF, PDF, PNG, and TIFF. Not all formats of [NSPasteboardType](https://developer.apple.com/documentation/appkit/nspasteboardtype?language=objc) are implemented.
 
-`set_contents` will return `True` if the pasteboard was successfully set; otherwise, `False`. It may also throw [RuntimeError](https://docs.python.org/3/library/exceptions.html#RuntimeError) if `data` can't be converted to an AppKit type, or if you attempt to set the `FileURL` type (since this doesn't work well).
+`set_contents` will return `True` if the pasteboard was successfully set; otherwise, `False`. It may also throw [RuntimeError](https://docs.python.org/3/library/exceptions.html#RuntimeError) if `data` can't be converted to an AppKit type.
+
+### Getting file URLs
+
+```pycon
+>>> import pasteboard
+>>> pb = pasteboard.Pasteboard()
+>>> pb.get_file_urls()
+('/Users/<user>/Documents/foo.txt', '/Users/<user>/Documents/bar.txt')
+```
+
+**Warning** This API is new, and may change in future.
+
+Returns a `Tuple` of strings, or `None`. Also supports the **diff** parameter analogue to `get_contents`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ takes two arguments:
 
 **type** - The format to set. Defaults to `pasteboard.String`, which corresponds to [NSPasteboardTypeString](https://developer.apple.com/documentation/appkit/nspasteboardtypestring?language=objc). See the `pasteboard` module members for other options such as HTML fragment, RTF, PDF, PNG, and TIFF. Not all formats of [NSPasteboardType](https://developer.apple.com/documentation/appkit/nspasteboardtype?language=objc) are implemented.
 
-`set_contents` will return `True` if the pasteboard was successfully set; otherwise, `False`. It may also throw [RuntimeError](https://docs.python.org/3/library/exceptions.html#RuntimeError) if `data` can't be converted to an AppKit type.
+`set_contents` will return `True` if the pasteboard was successfully set; otherwise, `False`. It may also throw [RuntimeError](https://docs.python.org/3/library/exceptions.html#RuntimeError) if `data` can't be converted to an AppKit type, or if you attempt to set the `FileURL` type (since this doesn't work well).
 
 ## Development
 

--- a/build.py
+++ b/build.py
@@ -6,6 +6,7 @@ assert sys.platform == "darwin", "pasteboard only works on macOS"
 pasteboard = Extension(
     "pasteboard._native",
     ["src/pasteboard/pasteboard.m"],
+    extra_compile_args=["-Wall", "-Wextra", "-Wpedantic", "-Werror"],
     extra_link_args=["-framework", "AppKit"],
     language="objective-c",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,10 @@ black = "^20.8b1"
 pytest = "^6.2.0"
 hypothesis = "^6.0.0"
 mypy = "^0.800"
-# This version is the last to support Python 3.6
+# This version is the last to support Python 3.6...
 ipython = "7.16.1"
+# ...and jedi is not properly pinned
+jedi = "0.17.2"
 
 [build-system]
 requires = ["poetry_core>=1.0.0", "setuptools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pasteboard"
-version = "0.3.2"
+version = "0.3.3"
 description = "Pasteboard - Python interface for reading from NSPasteboard (macOS clipboard)"
 authors = ["Toby Fleming <tobywf@users.noreply.github.com>"]
 license = "MPL-2.0"
@@ -26,13 +26,15 @@ keywords = ["macOS", "clipboard", "pasteboard"]
 build = "build.py"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = ">=3.6,<4.0"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"
-pytest = "^6.1.1"
-hypothesis = "^5.37.4"
-mypy = "^0.790"
+pytest = "^6.2.0"
+hypothesis = "^6.0.0"
+mypy = "^0.800"
+# This version is the last to support Python 3.6
+ipython = "7.16.1"
 
 [build-system]
 requires = ["poetry_core>=1.0.0", "setuptools"]

--- a/src/pasteboard/__init__.py
+++ b/src/pasteboard/__init__.py
@@ -8,3 +8,9 @@ import sys as _sys
 assert _sys.platform == "darwin", "pasteboard only works on macOS"
 
 from ._native import *
+
+
+class PasteboardType:
+    """Make type hints not fail on import - don't use this class"""
+
+    pass

--- a/src/pasteboard/__init__.py
+++ b/src/pasteboard/__init__.py
@@ -1,3 +1,8 @@
+# Pasteboard - Python interface for reading from NSPasteboard (macOS clipboard)
+# Copyright (C) 2017-2021  Toby Fleming
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
 import sys as _sys
 
 assert _sys.platform == "darwin", "pasteboard only works on macOS"

--- a/src/pasteboard/__init__.pyi
+++ b/src/pasteboard/__init__.pyi
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at https://mozilla.org/MPL/2.0/.
-from typing import overload, AnyStr, Optional, Union
+from typing import overload, AnyStr, Optional, Sequence, Union
 
 class PasteboardType: ...
 
@@ -14,13 +14,10 @@ RTF: PasteboardType
 String: PasteboardType
 TIFF: PasteboardType
 TabularText: PasteboardType
-FileURL: PasteboardType
 
 class Pasteboard:
     @classmethod
     def __init__(self) -> None: ...
-    @overload
-    def get_contents(self) -> str: ...
     @overload
     def get_contents(
         self,
@@ -37,3 +34,7 @@ class Pasteboard:
         data: AnyStr,
         type: PasteboardType = ...,
     ) -> bool: ...
+    def get_file_urls(
+        self,
+        diff: bool = ...,
+    ) -> Optional[Sequence[str]]: ...

--- a/src/pasteboard/__init__.pyi
+++ b/src/pasteboard/__init__.pyi
@@ -1,8 +1,11 @@
+# Pasteboard - Python interface for reading from NSPasteboard (macOS clipboard)
+# Copyright (C) 2017-2021  Toby Fleming
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
 from typing import overload, AnyStr, Optional, Union
 
-
 class PasteboardType: ...
-
 
 HTML: PasteboardType
 PDF: PasteboardType
@@ -11,28 +14,24 @@ RTF: PasteboardType
 String: PasteboardType
 TIFF: PasteboardType
 TabularText: PasteboardType
-
+FileURL: PasteboardType
 
 class Pasteboard:
     @classmethod
     def __init__(self) -> None: ...
-
     @overload
     def get_contents(self) -> str: ...
-
     @overload
     def get_contents(
         self,
         diff: bool = ...,
     ) -> Optional[str]: ...
-
     @overload
     def get_contents(
         self,
         type: PasteboardType = ...,
         diff: bool = ...,
     ) -> Union[str, bytes, None]: ...
-
     def set_contents(
         self,
         data: AnyStr,

--- a/src/pasteboard/pasteboard.m
+++ b/src/pasteboard/pasteboard.m
@@ -18,7 +18,7 @@ static NSAutoreleasePool *pool = NULL;
 typedef NSString * NSPasteboardType;
 static PyObject *PasteboardType_Default = NULL;
 
-typedef enum {DATA, STRING, URL} PasteboardTypeReading;
+typedef enum {DATA, STRING} PasteboardTypeReading;
 typedef struct {
     PyObject_HEAD
     NSPasteboardType type;
@@ -123,17 +123,6 @@ get_contents(NSPasteboard *board, PasteboardTypeState* type)
             return PyUnicode_FromString([str UTF8String]);
         }
 
-        case URL: {
-            // TODO: this seems to work for now... possibly, it would be better
-            // to use NSURL's URLFromPasteboard
-            NSString *str = [board stringForType:type->type];
-            if (!str) {
-                Py_RETURN_NONE;
-            }
-
-            return PyUnicode_FromString([str UTF8String]);
-        }
-
         default:
             PyErr_SetString(PyExc_RuntimeError, "Unknown pasteboard type");
             return NULL;
@@ -168,7 +157,7 @@ pasteboard_get_contents(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 PyDoc_STRVAR(pasteboard_get_contents__doc__,
-"get_contents(type, diff=False) -> str/bytes/None\n\n"
+"get_contents(type: PasteboardType = String, diff: bool = False) -> Union[str, bytes, None]\n\n"
 "Gets the contents of the pasteboard.\n\n"
 "type - The NSPasteboardType to get, see module members. Default is 'String'.\n"
 "diff - Only get the contents if it has changed. Otherwise, `None` is returned. "
@@ -221,11 +210,6 @@ set_contents(NSPasteboard *board, PasteboardTypeState* type, const char *bytes, 
             }
         }
 
-        case URL: {
-            PyErr_SetString(PyExc_RuntimeError, "URL pasteboard types cannot be set");
-            return NULL;
-        }
-
         default:
             PyErr_SetString(PyExc_RuntimeError, "Unknown pasteboard type");
             return NULL;
@@ -253,12 +237,73 @@ pasteboard_set_contents(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 PyDoc_STRVAR(pasteboard_set_contents__doc__,
-"set_contents(data, type) -> True/False/None\n\n"
+"set_contents(data: Union[str, bytes], type: PasteboardType = String) -> bool\n\n"
 "Sets the contents of the pasteboard.\n\n"
 "data - str or bytes-like object. If type is a string type and bytes is not "
 "UTF-8 encoded, the behaviour is undefined.\n"
 "type - The NSPasteboardType to get, see module members. Default is 'String'.\n"
 "Returns `True` if the operation was successful; otherwise, `False`.");
+
+static PyObject *
+pasteboard_get_file_urls(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PasteboardState *state = (PasteboardState *)self;
+    int diff = 0; // FALSE
+
+    static char *kwlist[] = {"diff", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|p", kwlist, &diff)) {
+        return NULL;
+    }
+
+    long long change_count = [state->board changeCount];
+
+    if (diff && (change_count == state->change_count)) {
+        Py_RETURN_NONE;
+    }
+
+    state->change_count = change_count;
+
+    // hopefully guard against non-file URLs
+    NSArray *supportedTypes = @[NSPasteboardTypeFileURL];
+    NSString *bestType = [state->board availableTypeFromArray:supportedTypes];
+    if (!bestType) {
+        Py_RETURN_NONE;
+    }
+
+    NSArray<Class> *classes = @[[NSURL class]];
+    NSDictionary *options = @{};
+    NSArray<NSURL*> *files = [state->board readObjectsForClasses:classes options:options];
+
+    Py_ssize_t len = (Py_ssize_t)[files count];
+    PyObject *urls = PyTuple_New(len);
+    Py_ssize_t pos = 0;
+    for (NSURL *url in files) {
+        NSString *str = [url path];
+        if ([url isFileURL] && str) {
+            PyTuple_SetItem(urls, pos, PyUnicode_FromString([str UTF8String]));
+            pos++;
+        }
+    }
+
+    if (len != pos) {
+        if (_PyTuple_Resize(&urls, pos) != 0) {
+            PyErr_SetString(PyExc_RuntimeError, "Internal error: failed to resize tuple");
+            return NULL;
+        }
+    }
+    return urls;
+}
+
+PyDoc_STRVAR(pasteboard_get_file_urls__doc__,
+"get_file_urls(diff: bool = False) -> Optional[Sequence[str]]\n\n"
+"Gets the contents of the pasteboard as file URLs.\n\n"
+"diff - Only get the contents if it has changed. Otherwise, `None` is returned. "
+"Can be used for efficiently querying the pasteboard when polling for changes."
+"Default is `False`.\n\n"
+"Returns a sequence of strings corresponding to the file URL's path. "
+"`None` is returned if an error occurred, there is no data of the requested "
+"type, or `diff` was set to `True` and the contents has not changed since "
+"the last query.");
 
 static PyMethodDef pasteboard_methods[] = {
     {
@@ -272,6 +317,12 @@ static PyMethodDef pasteboard_methods[] = {
         (PyCFunction)pasteboard_set_contents,
         METH_VARARGS | METH_KEYWORDS,
         pasteboard_set_contents__doc__,
+    },
+    {
+        "get_file_urls",
+        (PyCFunction)pasteboard_get_file_urls,
+        METH_VARARGS | METH_KEYWORDS,
+        pasteboard_get_file_urls__doc__,
     },
     {NULL, NULL, 0, NULL}  /* Sentinel */
 };
@@ -342,7 +393,6 @@ PyInit__native(void)
     PasteboardType_Default = __String;
     PASTEBOARD_TYPE(TIFF, DATA)
     PASTEBOARD_TYPE(TabularText, STRING)
-    PASTEBOARD_TYPE(FileURL, URL)
 
     Py_INCREF((PyObject *)&PasteboardType);
     if (PyModule_AddObject(module, "Pasteboard", (PyObject *)&PasteboardType) < 0) {

--- a/test_fileurl.m
+++ b/test_fileurl.m
@@ -1,0 +1,14 @@
+#include <AppKit/AppKit.h>
+
+int main() {
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+    NSPasteboard *pb = [NSPasteboard generalPasteboard];
+    [pb clearContents];
+    NSArray *objects = @[
+        [NSURL fileURLWithPath:@"/bin/ls"],
+        [NSURL URLWithString:@"https://developer.apple.com/"]
+    ];
+    [pb writeObjects:objects];
+    [pool drain];
+    return 0;
+}

--- a/tests.py
+++ b/tests.py
@@ -73,10 +73,18 @@ def test_get_set_contents_with_emoji_santa():
         (pasteboard.PDF, "com.adobe.pdf"),
         (pasteboard.PNG, "public.png"),
         (pasteboard.TIFF, "public.tiff"),
+        (pasteboard.FileURL, "public.file-url"),
     ],
 )
 def test_types_repr(type, name):
     assert repr(type) == "<PasteboardType {}>".format(name)
+
+
+def test_file_url_cannot_be_set():
+    pb = pasteboard.Pasteboard()
+    with pytest.raises(RuntimeError) as excinfo:
+        pb.set_contents("file://foo.bar", type=pasteboard.FileURL)
+    assert "cannot be set" in str(excinfo.value)
 
 
 def mypy_run(tmp_path, content):

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,10 @@ import pasteboard
 import pytest
 import mypy.api
 
-from hypothesis import assume, given, strategies as st
+from hypothesis import given, strategies as st
+from pasteboard import Pasteboard, PasteboardType
+from pathlib import Path
+from typing import Tuple
 
 STRING_TYPES = (
     pasteboard.String,
@@ -17,16 +20,15 @@ TEXT = st.characters(min_codepoint=1, blacklist_categories=("Cc", "Cs"))
 
 
 @given(TEXT)
-def test_get_set_contents_default(s):
-    assume(s.encode("utf-8"))
-    pb = pasteboard.Pasteboard()
+def test_get_set_contents_default(s: str) -> None:
+    pb = Pasteboard()
     assert pb.set_contents(s)
     assert pb.get_contents() == s
 
 
 @given(TEXT)
-def test_get_contents_diff_not_none_after_set(s):
-    pb = pasteboard.Pasteboard()
+def test_get_contents_diff_not_none_after_set(s: str) -> None:
+    pb = Pasteboard()
     assert pb.set_contents(s)
     assert pb.get_contents(diff=True) == s
     assert pb.get_contents(diff=True) is None
@@ -34,8 +36,8 @@ def test_get_contents_diff_not_none_after_set(s):
 
 @pytest.mark.parametrize("type", STRING_TYPES)
 @given(TEXT)
-def test_get_set_contents_string(type, s):
-    pb = pasteboard.Pasteboard()
+def test_get_set_contents_string(type: PasteboardType, s: str) -> None:
+    pb = Pasteboard()
     assert pb.set_contents(s, type=type)
     assert pb.get_contents(type=type) == s
     assert pb.get_contents(type=type, diff=True) is None
@@ -43,22 +45,22 @@ def test_get_set_contents_string(type, s):
 
 @pytest.mark.parametrize("type", BINARY_TYPES)
 @given(st.binary())
-def test_get_set_contents_data(type, s):
-    pb = pasteboard.Pasteboard()
-    assert pb.set_contents(s, type=type)
-    assert pb.get_contents(type=type) == s
+def test_get_set_contents_data(type: PasteboardType, b: bytes) -> None:
+    pb = Pasteboard()
+    assert pb.set_contents(b, type=type)
+    assert pb.get_contents(type=type) == b
     assert pb.get_contents(type=type, diff=True) is None
 
 
-def test_get_set_contents_with_null_char():
-    pb = pasteboard.Pasteboard()
+def test_get_set_contents_with_null_char() -> None:
+    pb = Pasteboard()
     assert pb.set_contents("abc\x00def")
     assert pb.get_contents() == "abc"
 
 
-def test_get_set_contents_with_emoji_santa():
+def test_get_set_contents_with_emoji_santa() -> None:
     s = "\x1f385"
-    pb = pasteboard.Pasteboard()
+    pb = Pasteboard()
     assert pb.set_contents(s)
     assert pb.get_contents() == s
 
@@ -73,21 +75,20 @@ def test_get_set_contents_with_emoji_santa():
         (pasteboard.PDF, "com.adobe.pdf"),
         (pasteboard.PNG, "public.png"),
         (pasteboard.TIFF, "public.tiff"),
-        (pasteboard.FileURL, "public.file-url"),
     ],
 )
-def test_types_repr(type, name):
-    assert repr(type) == "<PasteboardType {}>".format(name)
+def test_types_repr(type: PasteboardType, name: str) -> None:
+    assert repr(type) == f"<PasteboardType {name}>"
 
 
-def test_file_url_cannot_be_set():
-    pb = pasteboard.Pasteboard()
-    with pytest.raises(RuntimeError) as excinfo:
-        pb.set_contents("file://foo.bar", type=pasteboard.FileURL)
-    assert "cannot be set" in str(excinfo.value)
+def test_file_urls() -> None:
+    pb = Pasteboard()
+    assert pb.set_contents("abc\x00def")
+    assert pb.get_file_urls() is None
+    assert pb.get_file_urls(diff=True) is None
 
 
-def mypy_run(tmp_path, content):
+def mypy_run(tmp_path: Path, content: str) -> Tuple[str, str, int]:
     py = tmp_path / "test.py"
     py.write_text(content)
     filename = str(py)
@@ -95,7 +96,7 @@ def mypy_run(tmp_path, content):
     return normal_report.replace(filename, "test.py"), error_report, exit_status
 
 
-def test_type_hints_pasteboard_valid(tmp_path):
+def test_type_hints_pasteboard_valid(tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         """
@@ -106,7 +107,7 @@ pb = Pasteboard()
     assert exit_status == 0, normal_report
 
 
-def test_type_hints_pasteboard_invalid_args(tmp_path):
+def test_type_hints_pasteboard_invalid_args(tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         """
@@ -118,7 +119,7 @@ pb = Pasteboard("bar")
     assert 'Too many arguments for "Pasteboard"' in normal_report
 
 
-def test_type_hints_pasteboard_invalid_kwargs(tmp_path):
+def test_type_hints_pasteboard_invalid_kwargs(tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         """
@@ -130,19 +131,20 @@ pb = Pasteboard(foo="bar")
     assert 'Unexpected keyword argument "foo" for "Pasteboard"' in normal_report
 
 
-def test_type_hints_get_contents_valid_no_args(tmp_path):
+def test_type_hints_get_contents_valid_no_args(tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         """
 from pasteboard import Pasteboard
+from typing import Optional
 pb = Pasteboard()
-s: str = pb.get_contents()
+s: Optional[str] = pb.get_contents()
 """,
     )
     assert exit_status == 0, normal_report
 
 
-def test_type_hints_get_contents_valid_diff_arg(tmp_path):
+def test_type_hints_get_contents_valid_diff_arg(tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         """
@@ -156,7 +158,7 @@ if s:
     assert exit_status == 0, normal_report
 
 
-def test_type_hints_get_contents_valid_type_args(tmp_path):
+def test_type_hints_get_contents_valid_type_args(tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         """
@@ -174,7 +176,7 @@ if s:
     assert exit_status == 0, normal_report
 
 
-def test_type_hints_get_contents_valid_both_args(tmp_path):
+def test_type_hints_get_contents_valid_both_args(tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         """
@@ -193,7 +195,7 @@ if s:
 
 
 @pytest.mark.parametrize("arg", ['"bar"', 'foo="bar"', 'type="bar"', 'diff="bar"'])
-def test_type_hints_get_contents_invalid_arg(arg, tmp_path):
+def test_type_hints_get_contents_invalid_arg(arg: str, tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         f"""
@@ -207,7 +209,7 @@ pb.get_contents({arg})
 
 
 @pytest.mark.parametrize("arg", ['"bar"', 'b"bar"'])
-def test_type_hints_set_contents_valid_no_args(arg, tmp_path):
+def test_type_hints_set_contents_valid_no_args(arg: str, tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         f"""
@@ -220,7 +222,7 @@ result: bool = pb.set_contents({arg})
 
 
 @pytest.mark.parametrize("arg", ['"bar"', 'b"bar"'])
-def test_type_hints_set_contents_valid_type_args(arg, tmp_path):
+def test_type_hints_set_contents_valid_type_args(arg: str, tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         f"""
@@ -232,7 +234,7 @@ result: bool = pb.set_contents({arg}, type=PNG)
     assert exit_status == 0, normal_report
 
 
-def test_type_hints_set_contents_invalid_arg(tmp_path):
+def test_type_hints_set_contents_invalid_arg(tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         f"""
@@ -245,7 +247,7 @@ result: bool = pb.set_contents(0)
     assert '"set_contents" of "Pasteboard" cannot be "int"' in normal_report
 
 
-def test_type_hints_set_contents_invalid_type_arg(tmp_path):
+def test_type_hints_set_contents_invalid_type_arg(tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         f"""
@@ -259,7 +261,7 @@ result: bool = pb.set_contents("", type="bar")
     assert msg in normal_report
 
 
-def test_type_hints_set_contents_invalid_kwarg(tmp_path):
+def test_type_hints_set_contents_invalid_kwarg(tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         f"""
@@ -275,7 +277,7 @@ result: bool = pb.set_contents("", foo="bar")
     )
 
 
-def test_type_hints_set_contents_invalid_result(tmp_path):
+def test_type_hints_set_contents_invalid_result(tmp_path: Path) -> None:
     normal_report, error_report, exit_status = mypy_run(
         tmp_path,
         f"""


### PR DESCRIPTION
This should fix issue #9 . I decided to go with a different interface, since it's possible to select multiple files. Reading `public.file-url` as a string does work, but I'm not sure if this is great. Who can say with Apple's documentation? There are multiple ways of getting the information

* [stringForType](https://developer.apple.com/documentation/appkit/nspasteboard/1533566-stringfortype?language=occ) works
* [URLFromPasteboard](https://developer.apple.com/documentation/foundation/nsurl/1525106-urlfrompasteboard?language=objc), which [NSPasteboardTypeURL](https://developer.apple.com/documentation/appkit/nspasteboardtypeurl?language=objc) mentions but [NSPasteboardTypeFileURL](https://developer.apple.com/documentation/appkit/nspasteboardtypefileurl?language=objc) doesn't, even though FileURLs are just `NSURL`s with `isFileURL == YES`
* [readObjectsForClasses](https://developer.apple.com/documentation/appkit/nspasteboard/1524454-readobjectsforclasses?language=occ)

What leads me to believe `stringForType` isn't great is that setting file URLs via [setString:forType](https://developer.apple.com/documentation/appkit/nspasteboard/1528225-setstring?language=occ) doesn't work great. It makes my Finder spin for quite a while. Instead of exposing FileURL for `get_contents` and maybe having a special case in `set_contents`, I think this approach is quite nice.